### PR TITLE
Add FastAPI ingest service with Kafka logging

### DIFF
--- a/ingest_service/db.py
+++ b/ingest_service/db.py
@@ -1,0 +1,58 @@
+import os
+import sqlite3
+import threading
+from hashlib import sha256
+from typing import Optional
+
+DB_PATH = os.getenv("INGEST_LOG_DB", "/tmp/ingest_log.db")
+_lock = threading.Lock()
+
+
+def init_db() -> None:
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS ingest_log (
+                idempotency_key TEXT PRIMARY KEY,
+                checksum TEXT NOT NULL,
+                dedupe_count INTEGER NOT NULL
+            )
+            """
+        )
+        conn.commit()
+
+
+def log_ingest(idempotency_key: str, body: bytes) -> int:
+    checksum = sha256(body).hexdigest()
+    with _lock, sqlite3.connect(DB_PATH) as conn:
+        try:
+            conn.execute(
+                "INSERT INTO ingest_log (idempotency_key, checksum, dedupe_count) VALUES (?, ?, 1)",
+                (idempotency_key, checksum),
+            )
+            conn.commit()
+            return 1
+        except sqlite3.IntegrityError:
+            cur = conn.execute(
+                "SELECT checksum, dedupe_count FROM ingest_log WHERE idempotency_key=?",
+                (idempotency_key,),
+            )
+            row = cur.fetchone()
+            if row is None:
+                # unexpected, treat as new
+                conn.execute(
+                    "INSERT OR REPLACE INTO ingest_log (idempotency_key, checksum, dedupe_count) VALUES (?, ?, 1)",
+                    (idempotency_key, checksum),
+                )
+                conn.commit()
+                return 1
+            existing_checksum, dedupe_count = row
+            if existing_checksum != checksum:
+                raise ValueError("Checksum mismatch for Idempotency-Key")
+            dedupe_count += 1
+            conn.execute(
+                "UPDATE ingest_log SET dedupe_count=? WHERE idempotency_key=?",
+                (dedupe_count, idempotency_key),
+            )
+            conn.commit()
+            return dedupe_count

--- a/ingest_service/kafka.py
+++ b/ingest_service/kafka.py
@@ -1,0 +1,35 @@
+import json
+import logging
+import os
+from typing import Any, Dict
+
+try:
+    from kafka import KafkaProducer
+except Exception:  # pragma: no cover - dependency optional
+    KafkaProducer = None
+
+logger = logging.getLogger(__name__)
+
+
+class KafkaSink:
+    def __init__(self) -> None:
+        self.topic = os.getenv("KAFKA_TELEMETRY_TOPIC", "telemetry.raw")
+        servers = os.getenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+        if KafkaProducer:
+            try:  # pragma: no cover - best effort to initialise
+                self.producer = KafkaProducer(bootstrap_servers=servers)
+            except Exception:  # pragma: no cover - fallback when broker absent
+                logger.warning("Kafka producer init failed; running in noop mode", exc_info=True)
+                self.producer = None
+        else:  # pragma: no cover - used when kafka lib missing
+            self.producer = None
+
+    def publish(self, data: Dict[str, Any]) -> None:
+        payload = json.dumps(data).encode("utf-8")
+        if self.producer is None:
+            logger.info("Kafka producer unavailable; dropping payload")
+            return
+        try:  # pragma: no cover - network interaction
+            self.producer.send(self.topic, payload)
+        except Exception as exc:
+            logger.error("Kafka publish failed: %s", exc)

--- a/ingest_service/main.py
+++ b/ingest_service/main.py
@@ -1,0 +1,91 @@
+import os
+import re
+from fastapi import FastAPI, Header, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from . import db
+from .kafka import KafkaSink
+from .rate_limit import RateLimiter
+from .schemas import TelemetryV1, TripV1
+
+app = FastAPI()
+
+RATE_LIMIT_RATE = float(os.getenv("RATE_LIMIT_RATE", "5"))
+RATE_LIMIT_CAPACITY = int(os.getenv("RATE_LIMIT_CAPACITY", "10"))
+rate_limiter = RateLimiter(RATE_LIMIT_RATE, RATE_LIMIT_CAPACITY)
+producer = KafkaSink()
+
+
+def _parse_version(content_type: str, media: str) -> int:
+    pattern = rf"application/vnd.{media}.v(\d+)\+json"
+    m = re.fullmatch(pattern, content_type)
+    if not m:
+        raise HTTPException(status_code=415, detail="Unsupported Content-Type")
+    return int(m.group(1))
+
+
+@app.on_event("startup")
+async def startup() -> None:
+    db.init_db()
+
+
+@app.post("/telemetry", status_code=202)
+async def ingest_telemetry(
+    request: Request,
+    content_type: str = Header(..., alias="Content-Type"),
+    idempotency_key: str = Header(..., alias="Idempotency-Key"),
+    org_id: str = Header(..., alias="Org-Id"),
+):
+    allowed, retry_after = rate_limiter.consume(org_id)
+    if not allowed:
+        raise HTTPException(status_code=429, detail="Rate limit exceeded", headers={"Retry-After": str(int(retry_after))})
+
+    version = _parse_version(content_type, "telemetry")
+    if version != 1:
+        raise HTTPException(status_code=415, detail="Unsupported version")
+    body = await request.body()
+    try:
+        payload = TelemetryV1.model_validate_json(body)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    try:
+        dedupe_count = db.log_ingest(idempotency_key, body)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if dedupe_count > 1:
+        return JSONResponse(status_code=200, content={"status": "duplicate", "dedupe_count": dedupe_count})
+
+    producer.publish(payload.model_dump(mode="json"))
+    return {"status": "accepted"}
+
+
+@app.post("/trip", status_code=202)
+async def ingest_trip(
+    request: Request,
+    content_type: str = Header(..., alias="Content-Type"),
+    idempotency_key: str = Header(..., alias="Idempotency-Key"),
+    org_id: str = Header(..., alias="Org-Id"),
+):
+    allowed, retry_after = rate_limiter.consume(org_id)
+    if not allowed:
+        raise HTTPException(status_code=429, detail="Rate limit exceeded", headers={"Retry-After": str(int(retry_after))})
+
+    version = _parse_version(content_type, "trip")
+    if version != 1:
+        raise HTTPException(status_code=415, detail="Unsupported version")
+    body = await request.body()
+    try:
+        payload = TripV1.model_validate_json(body)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    try:
+        dedupe_count = db.log_ingest(idempotency_key, body)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if dedupe_count > 1:
+        return JSONResponse(status_code=200, content={"status": "duplicate", "dedupe_count": dedupe_count})
+
+    producer.publish(payload.model_dump(mode="json"))
+    return {"status": "accepted"}

--- a/ingest_service/rate_limit.py
+++ b/ingest_service/rate_limit.py
@@ -1,0 +1,38 @@
+import threading
+import time
+from typing import Dict, Tuple
+
+
+class TokenBucket:
+    def __init__(self, rate: float, capacity: int) -> None:
+        self.rate = rate
+        self.capacity = capacity
+        self.tokens = capacity
+        self.timestamp = time.monotonic()
+
+    def consume(self, tokens: int = 1) -> Tuple[bool, float]:
+        now = time.monotonic()
+        elapsed = now - self.timestamp
+        self.timestamp = now
+        self.tokens = min(self.capacity, self.tokens + elapsed * self.rate)
+        if self.tokens < tokens:
+            retry_after = (tokens - self.tokens) / self.rate if self.rate else 1
+            return False, retry_after
+        self.tokens -= tokens
+        return True, 0.0
+
+
+class RateLimiter:
+    def __init__(self, rate: float, capacity: int) -> None:
+        self.rate = rate
+        self.capacity = capacity
+        self.buckets: Dict[str, TokenBucket] = {}
+        self.lock = threading.Lock()
+
+    def consume(self, org_id: str, tokens: int = 1) -> Tuple[bool, float]:
+        with self.lock:
+            bucket = self.buckets.get(org_id)
+            if bucket is None:
+                bucket = TokenBucket(self.rate, self.capacity)
+                self.buckets[org_id] = bucket
+            return bucket.consume(tokens)

--- a/ingest_service/schemas.py
+++ b/ingest_service/schemas.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Tuple
+
+from pydantic import BaseModel, Field
+
+
+class TelemetryV1(BaseModel):
+    device_id: str
+    timestamp: datetime
+    lat: float
+    lon: float
+
+
+class TripV1(BaseModel):
+    trip_id: str
+    vehicle_id: str
+    start_time: datetime
+    end_time: datetime | None = None
+    route: List[Tuple[float, float]] = Field(default_factory=list)

--- a/ingest_service/tests/test_ingest.py
+++ b/ingest_service/tests/test_ingest.py
@@ -1,0 +1,47 @@
+import importlib
+import os
+import tempfile
+
+from fastapi.testclient import TestClient
+
+
+def create_app(rate="5", capacity="10"):
+    tmpdir = tempfile.mkdtemp()
+    os.environ["INGEST_LOG_DB"] = os.path.join(tmpdir, "ingest.db")
+    os.environ["RATE_LIMIT_RATE"] = str(rate)
+    os.environ["RATE_LIMIT_CAPACITY"] = str(capacity)
+    db_module = importlib.import_module("ingest_service.db")
+    importlib.reload(db_module)
+    module = importlib.import_module("ingest_service.main")
+    importlib.reload(module)
+    return module.app, module
+
+
+def _headers():
+    return {
+        "Content-Type": "application/vnd.telemetry.v1+json",
+        "Idempotency-Key": "abc123",
+        "Org-Id": "org1",
+    }
+
+
+def test_deduplication():
+    app, _ = create_app()
+    payload = {"device_id": "d1", "timestamp": "2024-01-01T00:00:00Z", "lat": 0.0, "lon": 0.0}
+    with TestClient(app) as client:
+        r1 = client.post("/telemetry", json=payload, headers=_headers())
+        assert r1.status_code == 202
+        r2 = client.post("/telemetry", json=payload, headers=_headers())
+        assert r2.status_code == 200
+        assert r2.json()["dedupe_count"] == 2
+
+
+def test_rate_limit():
+    app, module = create_app(rate=0, capacity=1)
+    payload = {"device_id": "d1", "timestamp": "2024-01-01T00:00:00Z", "lat": 0.0, "lon": 0.0}
+    with TestClient(app) as client:
+        r1 = client.post("/telemetry", json=payload, headers=_headers())
+        assert r1.status_code == 202
+        r2 = client.post("/telemetry", json=payload, headers=_headers())
+        assert r2.status_code == 429
+        assert "Retry-After" in r2.headers


### PR DESCRIPTION
## Summary
- add new ingest_service module with FastAPI endpoints for telemetry and trip ingestion
- implement idempotency log and token bucket rate limiting per org
- write validated payloads to Kafka topic `telemetry.raw`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a62804ca8c83249197dfc880263416