### PR TITLE
Add Debezium connector registration script and dbt lineage

### DIFF
--- a/dbt/models/exposures.yml
+++ b/dbt/models/exposures.yml
@@ -1,0 +1,12 @@
+version: 2
+
+exposures:
+  - name: orders_dashboard
+    type: dashboard
+    url: https://example.com/dashboards/orders
+    description: "Dashboard built from curated orders mart"
+    depends_on:
+      - ref('orders')
+    owner:
+      name: analytics
+      email: analytics@example.com

--- a/dbt/models/marts/orders.sql
+++ b/dbt/models/marts/orders.sql
@@ -1,1 +1,2 @@
-select 1 as id
+select *
+from {{ source('raw', 'orders') }}

--- a/dbt/models/sources.yml
+++ b/dbt/models/sources.yml
@@ -1,0 +1,6 @@
+version: 2
+
+sources:
+  - name: raw
+    tables:
+      - name: orders

--- a/deploy/register-connectors.sh
+++ b/deploy/register-connectors.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+CONNECT_URL=${CONNECT_URL:-http://localhost:8083}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+register() {
+  local name=$1
+  echo "Registering $name connector"
+  curl -s -X PUT -H "Content-Type: application/json" \
+    --data @"$SCRIPT_DIR/debezium/${name}.json" \
+    "$CONNECT_URL/connectors/${name}/config" > /dev/null
+}
+
+register postgres-source
+register iceberg-sink
+
+echo "Connectors registered"


### PR DESCRIPTION
## Summary
- add script to register Debezium Postgres source and Iceberg sink connectors
- model raw `orders` source and dashboard exposure for dbt lineage

## Testing
- `DJANGO_SETTINGS_MODULE=gutumanu.settings pytest analytics/tests.py -q` *(fails: Apps aren't loaded yet)*

------
https://chatgpt.com/codex/tasks/task_e_68a700dd79808324a2854ef4224cd9a8